### PR TITLE
Redesign blog look and feel

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,25 +1,12 @@
 ---
 permalink: /404.html
 layout: default
+title: Page Not Found
 ---
 
-<style type="text/css" media="screen">
-  .container {
-    margin: 10px auto;
-    max-width: 600px;
-    text-align: center;
-  }
-  h1 {
-    margin: 30px 0;
-    font-size: 4em;
-    line-height: 1;
-    letter-spacing: -1px;
-  }
-</style>
-
-<div class="container">
+<div class="error-page">
   <h1>404</h1>
-
-  <p><strong>Page not found :(</strong></p>
+  <p><strong>Page not found.</strong></p>
   <p>The requested page could not be found.</p>
+  <a href="{{ '/' | relative_url }}" class="back-link">&larr; Back to home</a>
 </div>

--- a/_config.yml
+++ b/_config.yml
@@ -36,3 +36,18 @@ kramdown:
   auto_ids: true
   hard_wrap: false
   syntax_highlighter: rouge
+
+defaults:
+  - scope:
+      path: ""
+      type: "posts"
+    values:
+      layout: "post"
+  - scope:
+      path: "index.md"
+    values:
+      layout: "home"
+  - scope:
+      path: "about.md"
+    values:
+      layout: "default"

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,7 +3,9 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {%- seo -%}
-  <link href="https://unpkg.com/@primer/css/dist/primer.css" rel="stylesheet" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;1,9..40,400&family=Lora:ital,wght@0,400;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
   {%- feed_meta -%}
   {%- if jekyll.environment == 'production' and site.google_analytics -%}
@@ -12,18 +14,17 @@
 
   {% if site.use_math %}
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
-    <script type="text/javascript" async src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML"> </script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script>
       document.addEventListener("DOMContentLoaded", function() {
-        renderMathInElement( document.body, {
+        renderMathInElement(document.body, {
           delimiters: [
             {left: "$$", right: "$$", display: true},
             {left: "[%", right: "%]", display: true},
             {left: "$", right: "$", display: false}
-          ]}
-        );
+          ]
+        });
       });
     </script>
   {% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="{{ page.lang | default: site.lang | default: "en" }}">
+  {%- include head.html -%}
+  <body>
+
+    <header class="site-header">
+      <div class="site-header__inner">
+        <a class="site-title" href="{{ "/" | relative_url }}">
+          <span class="site-title__initials">PV</span>
+          <span class="site-title__text">{{ site.title | escape }}</span>
+        </a>
+        <nav class="site-nav">
+          <a href="{{ "/" | relative_url }}" class="nav-link">Posts</a>
+          <a href="{{ "/about" | relative_url }}" class="nav-link">About</a>
+        </nav>
+      </div>
+    </header>
+
+    <main class="site-main">
+      {{ content }}
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-footer__inner">
+        <p class="site-footer__tagline">{{ site.description | escape }}</p>
+        <div class="site-footer__links">
+          <a href="https://github.com/{{ site.github_username | cgi_escape | escape }}" target="_blank" rel="noopener">GitHub</a>
+          {%- if site.linkedin_username -%}
+          <a href="https://linkedin.com/in/{{ site.linkedin_username | cgi_escape | escape }}" target="_blank" rel="noopener">LinkedIn</a>
+          {%- endif -%}
+          <a href="{{ '/feed.xml' | relative_url }}">RSS</a>
+        </div>
+      </div>
+    </footer>
+
+  </body>
+</html>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,0 +1,31 @@
+---
+layout: default
+---
+
+<div class="home">
+  {%- if content and content != "" -%}
+  <p class="home-intro">{{ content | strip_html | strip }}</p>
+  {%- endif -%}
+
+  <h2 class="posts-heading">Writing</h2>
+
+  <div class="post-grid">
+    {%- for post in site.posts -%}
+    <article class="post-card">
+      <a href="{{ post.url | relative_url }}" class="post-card__link">
+        <div class="post-card__body">
+          <time class="post-card__date" datetime="{{ post.date | date_to_xmlschema }}">
+            {{ post.date | date: "%b %d, %Y" }}
+          </time>
+          <h3 class="post-card__title">{{ post.title | escape }}</h3>
+          {%- assign excerpt_text = post.excerpt | strip_html | strip | truncatewords: 28 -%}
+          {%- if excerpt_text and excerpt_text != "" -%}
+          <p class="post-card__excerpt">{{ excerpt_text }}</p>
+          {%- endif -%}
+        </div>
+        <span class="post-card__arrow">&#8594;</span>
+      </a>
+    </article>
+    {%- endfor -%}
+  </div>
+</div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,26 @@
+---
+layout: default
+---
+
+<article class="post">
+
+  <header class="post-header">
+    <div class="post-meta">
+      <time datetime="{{ page.date | date_to_xmlschema }}">
+        {{ page.date | date: "%B %d, %Y" }}
+      </time>
+      <span class="post-meta__sep">&middot;</span>
+      <span>{{ content | number_of_words | divided_by: 200 | plus: 1 }} min read</span>
+    </div>
+    <h1 class="post-title">{{ page.title | escape }}</h1>
+  </header>
+
+  <div class="post-content">
+    {{ content }}
+  </div>
+
+  <footer class="post-footer">
+    <a href="{{ '/' | relative_url }}" class="back-link">&larr; Back to all posts</a>
+  </footer>
+
+</article>

--- a/about.md
+++ b/about.md
@@ -1,6 +1,17 @@
-# About
+---
+layout: default
+title: About
+---
 
-* Pranay Vasani 
-* Mumbaikar living in Pune
-* Still discovering my journey
-* Family man
+<div class="about-page">
+
+<h1>About</h1>
+
+<ul>
+  <li>Pranay Vasani</li>
+  <li>Mumbaikar living in Pune</li>
+  <li>Still discovering my journey</li>
+  <li>Family man</li>
+</ul>
+
+</div>

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -1,0 +1,600 @@
+---
+---
+
+/* =========================================
+   PRANAYVASANI.GITHUB.IO — CUSTOM THEME
+   ========================================= */
+
+/* === CSS VARIABLES === */
+:root {
+  /* Colors — Light */
+  --color-bg: #fafaf8;
+  --color-surface: #ffffff;
+  --color-text: #1c1c1a;
+  --color-text-muted: #6b7280;
+  --color-text-faint: #9ca3af;
+  --color-accent: #1a6e5c;
+  --color-accent-hover: #145a4c;
+  --color-accent-light: #e6f3f0;
+  --color-border: #e5e7eb;
+  --color-code-bg: #f3f4f6;
+  --color-header-bg: rgba(250, 250, 248, 0.92);
+
+  /* Typography */
+  --font-sans: 'DM Sans', system-ui, -apple-system, sans-serif;
+  --font-serif: 'Lora', Georgia, serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+
+  /* Layout */
+  --max-width: 700px;
+  --max-width-wide: 960px;
+  --header-height: 60px;
+
+  /* Transitions */
+  --transition: 150ms ease;
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-bg: #111110;
+    --color-surface: #1a1a18;
+    --color-text: #e8e6e1;
+    --color-text-muted: #9ca3af;
+    --color-text-faint: #6b7280;
+    --color-accent: #4db89e;
+    --color-accent-hover: #5ec9af;
+    --color-accent-light: #0d2520;
+    --color-border: #2a2a28;
+    --color-code-bg: #1e1e1c;
+    --color-header-bg: rgba(17, 17, 16, 0.92);
+  }
+}
+
+/* === RESET === */
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 18px;
+  -webkit-text-size-adjust: 100%;
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  font-size: 1rem;
+  line-height: 1.7;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+a {
+  color: var(--color-accent);
+  text-decoration: none;
+  transition: color var(--transition);
+}
+
+a:hover {
+  color: var(--color-accent-hover);
+  text-decoration: underline;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 6px;
+}
+
+/* === HEADER === */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: var(--color-header-bg);
+  border-bottom: 1px solid var(--color-border);
+  height: var(--header-height);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+}
+
+.site-header__inner {
+  max-width: var(--max-width-wide);
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-title {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  text-decoration: none;
+  color: var(--color-text);
+  font-weight: 600;
+}
+
+.site-title:hover {
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+.site-title__initials {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  background: var(--color-accent);
+  color: #fff;
+  border-radius: 7px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  flex-shrink: 0;
+}
+
+.site-title__text {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  font-weight: 400;
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.25rem;
+  align-items: center;
+}
+
+.nav-link {
+  color: var(--color-text-muted);
+  text-decoration: none;
+  font-size: 0.875rem;
+  font-weight: 500;
+  transition: color var(--transition);
+}
+
+.nav-link:hover {
+  color: var(--color-text);
+  text-decoration: none;
+}
+
+.nav-link.active {
+  color: var(--color-accent);
+}
+
+/* === MAIN CONTAINER === */
+.site-main {
+  flex: 1;
+  padding: 3rem 1.5rem;
+  max-width: var(--max-width-wide);
+  margin: 0 auto;
+  width: 100%;
+}
+
+/* === HOME PAGE === */
+.home-intro {
+  font-family: var(--font-serif);
+  font-size: 1.1rem;
+  color: var(--color-text-muted);
+  margin: 0 0 3rem;
+  max-width: 540px;
+  line-height: 1.75;
+  font-style: italic;
+}
+
+.posts-heading {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-text-faint);
+  margin: 0 0 1rem;
+}
+
+/* === POST CARDS === */
+.post-grid {
+  display: flex;
+  flex-direction: column;
+}
+
+.post-card {
+  border-top: 1px solid var(--color-border);
+}
+
+.post-card:last-child {
+  border-bottom: 1px solid var(--color-border);
+}
+
+.post-card__link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.1rem 0;
+  text-decoration: none;
+  color: inherit;
+  gap: 1rem;
+}
+
+.post-card__link:hover {
+  color: inherit;
+  text-decoration: none;
+}
+
+.post-card__link:hover .post-card__title {
+  color: var(--color-accent);
+}
+
+.post-card__link:hover .post-card__arrow {
+  transform: translateX(4px);
+  color: var(--color-accent);
+}
+
+.post-card__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.post-card__date {
+  font-size: 0.75rem;
+  color: var(--color-text-faint);
+  font-weight: 500;
+  display: block;
+  margin-bottom: 0.2rem;
+  font-family: var(--font-sans);
+}
+
+.post-card__title {
+  font-family: var(--font-sans);
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text);
+  margin: 0 0 0.2rem;
+  transition: color var(--transition);
+  line-height: 1.4;
+}
+
+.post-card__excerpt {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  margin: 0;
+  line-height: 1.5;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.post-card__arrow {
+  font-size: 1rem;
+  color: var(--color-text-faint);
+  transition: transform var(--transition), color var(--transition);
+  flex-shrink: 0;
+}
+
+/* === POST PAGE === */
+.post {
+  max-width: var(--max-width);
+  margin: 0 auto;
+}
+
+.post-header {
+  margin-bottom: 2.5rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.post-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--color-text-faint);
+  font-weight: 500;
+  margin-bottom: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-family: var(--font-sans);
+}
+
+.post-meta__sep {
+  opacity: 0.4;
+}
+
+.post-title {
+  font-family: var(--font-serif);
+  font-size: clamp(1.6rem, 4vw, 2.3rem);
+  font-weight: 600;
+  color: var(--color-text);
+  line-height: 1.25;
+  margin: 0;
+}
+
+/* Post body typography */
+.post-content {
+  font-family: var(--font-serif);
+  font-size: 1.05rem;
+  line-height: 1.85;
+  color: var(--color-text);
+}
+
+.post-content p {
+  margin: 0 0 1.4rem;
+}
+
+.post-content h1,
+.post-content h2,
+.post-content h3,
+.post-content h4,
+.post-content h5,
+.post-content h6 {
+  font-family: var(--font-sans);
+  font-weight: 600;
+  margin-top: 2.5rem;
+  margin-bottom: 0.9rem;
+  color: var(--color-text);
+  line-height: 1.3;
+}
+
+.post-content h2 { font-size: 1.35rem; }
+.post-content h3 { font-size: 1.15rem; }
+.post-content h4 { font-size: 1rem; }
+
+.post-content a {
+  color: var(--color-accent);
+  text-decoration: underline;
+  text-decoration-color: var(--color-accent-light);
+  text-underline-offset: 2px;
+  transition: text-decoration-color var(--transition);
+}
+
+.post-content a:hover {
+  text-decoration-color: var(--color-accent);
+}
+
+.post-content ul,
+.post-content ol {
+  padding-left: 1.5rem;
+  margin: 0 0 1.4rem;
+}
+
+.post-content li {
+  margin-bottom: 0.4rem;
+}
+
+.post-content blockquote {
+  border-left: 3px solid var(--color-accent);
+  margin: 2rem 0;
+  padding: 0.9rem 1.25rem;
+  background: var(--color-accent-light);
+  border-radius: 0 6px 6px 0;
+  font-style: italic;
+  color: var(--color-text-muted);
+}
+
+.post-content blockquote p:last-child {
+  margin: 0;
+}
+
+.post-content code {
+  font-family: var(--font-mono);
+  font-size: 0.875em;
+  background: var(--color-code-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 0.1em 0.35em;
+}
+
+.post-content pre {
+  background: var(--color-code-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 1.2rem 1.4rem;
+  overflow-x: auto;
+  margin: 1.5rem 0;
+  font-size: 0.875rem;
+  line-height: 1.65;
+}
+
+.post-content pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: inherit;
+}
+
+.post-content img {
+  border: 1px solid var(--color-border);
+  margin: 1.5rem 0;
+  display: block;
+}
+
+.post-content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: 0.9rem;
+  font-family: var(--font-sans);
+}
+
+.post-content th,
+.post-content td {
+  padding: 0.55rem 0.9rem;
+  border: 1px solid var(--color-border);
+  text-align: left;
+}
+
+.post-content th {
+  background: var(--color-code-bg);
+  font-weight: 600;
+}
+
+.post-content hr {
+  border: none;
+  border-top: 1px solid var(--color-border);
+  margin: 2.5rem 0;
+}
+
+.post-footer {
+  margin-top: 3.5rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--color-border);
+}
+
+.back-link {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  transition: color var(--transition);
+}
+
+.back-link:hover {
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+/* === ABOUT PAGE === */
+.about-page {
+  max-width: var(--max-width);
+  margin: 0 auto;
+}
+
+.about-page h1 {
+  font-family: var(--font-serif);
+  font-size: clamp(1.6rem, 4vw, 2.3rem);
+  font-weight: 600;
+  color: var(--color-text);
+  margin: 0 0 2rem;
+  line-height: 1.25;
+}
+
+.about-page p,
+.about-page li {
+  font-family: var(--font-serif);
+  font-size: 1.05rem;
+  line-height: 1.8;
+  color: var(--color-text-muted);
+}
+
+.about-page ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.about-page li {
+  padding: 0.65rem 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.about-page li:last-child {
+  border-bottom: none;
+}
+
+.about-page a {
+  color: var(--color-accent);
+}
+
+/* === FOOTER === */
+.site-footer {
+  border-top: 1px solid var(--color-border);
+  padding: 2.5rem 1.5rem;
+  background: var(--color-surface);
+}
+
+.site-footer__inner {
+  max-width: var(--max-width-wide);
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.site-footer__tagline {
+  font-size: 0.8rem;
+  color: var(--color-text-faint);
+  margin: 0;
+  font-style: italic;
+}
+
+.site-footer__links {
+  font-size: 0.8rem;
+  color: var(--color-text-faint);
+  margin: 0;
+  display: flex;
+  gap: 1.25rem;
+}
+
+.site-footer__links a {
+  color: var(--color-text-muted);
+  text-decoration: none;
+  transition: color var(--transition);
+}
+
+.site-footer__links a:hover {
+  color: var(--color-accent);
+}
+
+/* === 404 PAGE === */
+.error-page {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  text-align: center;
+  padding: 4rem 0;
+}
+
+.error-page h1 {
+  font-family: var(--font-serif);
+  font-size: 5rem;
+  color: var(--color-accent);
+  margin: 0 0 1rem;
+  line-height: 1;
+}
+
+.error-page p {
+  color: var(--color-text-muted);
+  margin-bottom: 2rem;
+}
+
+/* === RESPONSIVE === */
+@media (max-width: 600px) {
+  html {
+    font-size: 16px;
+  }
+
+  .site-header__inner {
+    padding: 0 1rem;
+  }
+
+  .site-title__text {
+    display: none;
+  }
+
+  .site-main {
+    padding: 2rem 1rem;
+  }
+
+  .site-footer {
+    padding: 2rem 1rem;
+  }
+
+  .site-footer__inner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/index.md
+++ b/index.md
@@ -1,1 +1,5 @@
-Hello and welcome to Pranay Vasani's blog. 
+---
+layout: home
+---
+
+Hello and welcome to Pranay Vasani's blog — a personal place to share thoughts on technology, business, books, and everything in between.


### PR DESCRIPTION
## What's changed

A full visual redesign of the blog, staying within Jekyll's override mechanism — no theme swap needed.

### New files
- **`assets/main.scss`** — Custom CSS from scratch: CSS variables, teal accent color (`#1a6e5c`), auto dark mode via `prefers-color-scheme`, DM Sans (headings/UI) + Lora (body/serif) + JetBrains Mono (code)
- **`_layouts/default.html`** — Sticky frosted-glass header with `PV` initials badge, clean nav (Posts / About), compact footer
- **`_layouts/home.html`** — Post cards list: date → title → excerpt → arrow, replaces plain date+title list
- **`_layouts/post.html`** — Serif reading view with estimated read time and "Back to all posts" link

### Updated files
- **`_includes/head.html`** — Removed Primer CSS, added Google Fonts preconnect
- **`_config.yml`** — Added layout defaults so posts auto-use `post` layout
- **`index.md` / `about.md` / `404.html`** — Aligned with new layouts