### PR TITLE
Fix post page header, nav and footer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="{{ page.lang | default: site.lang | default: 'en' }}">
+  {%- include head.html -%}
+  <body>
+
+    <header class="site-header" role="banner">
+      <div class="wrapper">
+        <a class="site-brand" href="{{ '/' | relative_url }}" rel="author">
+          <span class="site-brand__badge">PV</span>
+        </a>
+
+        <nav class="site-nav">
+          <input type="checkbox" id="nav-trigger" class="nav-trigger" />
+          <label for="nav-trigger">
+            <span class="menu-icon">
+              <svg viewBox="0 0 18 15" width="18px" height="15px">
+                <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.032C17.335,0,18,0.665,18,1.484L18,1.484z M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.032C17.335,6.031,18,6.696,18,7.516L18,7.516z M18,13.516C18,14.335,17.335,15,16.516,15H1.484C0.665,15,0,14.335,0,13.516l0,0c0-0.82,0.665-1.484,1.484-1.484 h15.032C17.335,12.031,18,12.696,18,13.516L18,13.516z"/>
+              </svg>
+            </span>
+          </label>
+          <div class="trigger">
+            <a class="page-link" href="{{ '/' | relative_url }}">Posts</a>
+            <a class="page-link" href="{{ '/about' | relative_url }}">About</a>
+          </div>
+        </nav>
+      </div>
+    </header>
+
+    <main class="page-content" aria-label="Content">
+      <div class="wrapper">
+        {{ content }}
+      </div>
+    </main>
+
+    <footer class="site-footer">
+      <div class="wrapper">
+        <p class="site-footer__text">
+          {{ site.description | escape }} &mdash;
+          <a href="https://github.com/{{ site.github_username | escape }}">GitHub</a>
+          &middot; <a href="{{ '/feed.xml' | relative_url }}">RSS</a>
+        </p>
+      </div>
+    </footer>
+
+  </body>
+</html>

--- a/about.md
+++ b/about.md
@@ -3,15 +3,9 @@ layout: default
 title: About
 ---
 
-<div class="about-page">
+# About
 
-<h1>About</h1>
-
-<ul>
-  <li>Pranay Vasani</li>
-  <li>Mumbaikar living in Pune</li>
-  <li>Still discovering my journey</li>
-  <li>Family man</li>
-</ul>
-
-</div>
+- Pranay Vasani
+- Mumbaikar living in Pune
+- Still discovering my journey
+- Family man

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -5,9 +5,54 @@
 
 /* === Improvements layered on top of Minima === */
 
-/* Better fonts — system stack with optional Google Fonts enhancement */
+/* Better fonts — system stack */
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+}
+
+/* ── PV Badge in header ───────────────────────── */
+.site-brand {
+  display: inline-flex;
+  align-items: center;
+  text-decoration: none;
+  line-height: 1;
+}
+
+.site-brand:hover {
+  text-decoration: none;
+}
+
+.site-brand__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  background: #1a6e5c;
+  color: #fff;
+  border-radius: 7px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+}
+
+/* Hide Minima's auto-generated .site-title since we use .site-brand */
+.site-title { display: none; }
+
+/* ── Footer ───────────────────────────────────── */
+.site-footer__text {
+  font-size: 0.85rem;
+  color: #828282;
+  margin: 0;
+}
+
+.site-footer__text a {
+  color: #828282;
+}
+
+.site-footer__text a:hover {
+  color: #1a6e5c;
+  text-decoration: none;
 }
 
 /* Slightly wider content column */


### PR DESCRIPTION
Fixes three issues visible on post pages:

1. **Removes site title from header** — replaces the "Confused aatma..." text link with just the clean PV badge
2. **Removes "Page Not Found" from nav** — hardcodes only Posts and About in the nav (Minima's auto-nav was picking up the 404 page)
3. **Removes duplicate site title from footer** — replaces Minima's verbose footer with a single clean line: description + GitHub + RSS
4. **Fixes about page** — plain markdown, no broken wrapper div