### PR TITLE
Add PSP explainer blog post with embedded sketch-note SVG

### DIFF
--- a/_posts/2026-04-22-HowPatientSupportProgramsDrivePharmaGrowth.md
+++ b/_posts/2026-04-22-HowPatientSupportProgramsDrivePharmaGrowth.md
@@ -1,0 +1,122 @@
+---
+tags: [Pharma, Analytics, Healthcare]
+---
+
+# How Patient Support Programs Drive Pharma Growth (Explained Simply)
+
+If you think getting a prescription means a patient immediately starts treatment in the US… think again.
+
+Behind every prescription lies a complex journey—insurance approvals, affordability checks, and logistical hurdles. This is where Patient Support Programs (PSPs) come in. They are not just "support systems"—they are critical business engines that help patients actually start and stay on therapy.
+
+Let’s break it down in a simple way.
+
+> **Sketch note overview**
+>
+> ![Patient Support Program (PSP) sketch note overview](/images/psp-sketch-note.svg)
+>
+> *High-level visual summary of the end-to-end PSP journey and key business metrics.*
+
+---
+
+## The Patient Journey: From Prescription to Therapy
+
+A typical journey looks like this:
+
+**Doctor prescribes → Patient enrolls → Insurance approves → Drug is delivered → Patient continues therapy**
+
+Sounds straightforward, right? In reality, patients can drop off at any stage.
+
+---
+
+## Step-by-Step: What Really Happens
+
+### 1) Prescription
+A doctor recommends a drug. But approval from insurance is still required.
+
+### 2) Enrollment
+The patient (or doctor’s office) submits details into a PSP system, usually managed by a “hub” vendor.
+
+### 3) Benefits Investigation
+The hub checks if the insurance will cover the drug and what the patient will need to pay.
+
+### 4) Prior Authorization (PA)
+Sometimes insurers ask for more proof. This slows things down and often becomes a major bottleneck.
+
+### 5) Financial Assistance
+If costs are too high, programs like copay cards or free drug support step in.
+
+### 6) Dispensing
+The drug is shipped via specialty pharmacies.
+
+### 7) Therapy & Adherence
+Once therapy begins, PSPs help patients stay on track through reminders and support.
+
+---
+
+## Why PSPs Matter (From a Business Lens)
+
+Here’s the key insight:
+
+**No PSP = fewer patients start therapy**  
+**Fewer starts = lower revenue**
+
+PSPs are essentially conversion engines. They ensure that patients don’t drop off before starting treatment—and that they continue therapy over time.
+
+---
+
+## The Players Involved
+
+- **Pharma companies** – Own the drug and fund the PSP
+- **Hub vendors** – Run the operations
+- **Doctors (HCPs)** – Prescribe and submit documentation
+- **Payers (insurance)** – Approve or deny coverage
+- **Specialty pharmacies** – Deliver the drug
+- **Patients** – The center of it all
+
+---
+
+## What Gets Measured (And Why It Matters)
+
+To run PSPs effectively, pharma teams track key metrics:
+
+- **Enrollment rate** – Are patients entering the system?
+- **Approval rate** – Are insurers approving therapy?
+- **Time to therapy** – How quickly do patients start?
+- **Conversion rate** – How many actually begin treatment?
+- **Drop-offs** – Where are patients getting stuck?
+- **Adherence** – Are patients continuing treatment?
+
+Each metric directly impacts revenue and patient outcomes.
+
+---
+
+## Where Analytics Comes In
+
+This is where analytics platforms (like epioxa-style systems) play a huge role.
+
+They help answer questions like:
+
+- Where are patients dropping off the most?
+- Which insurers are causing delays?
+- Which providers are converting better?
+- Why did therapy starts decline last month?
+
+By identifying bottlenecks, pharma teams can fix issues faster and improve patient access.
+
+---
+
+## The Big Takeaway
+
+Patient Support Programs are not just about helping patients—they are about ensuring access, improving outcomes, and driving business growth.
+
+Think of PSPs as a pipeline:
+
+- Every step matters
+- Every delay costs
+- Every improvement drives impact
+
+And the better you understand this pipeline, the more effectively you can optimize it.
+
+---
+
+If you’re working in pharma analytics, PSPs are one of the most powerful areas to explore—they sit right at the intersection of patient care and business performance.

--- a/images/psp-sketch-note.svg
+++ b/images/psp-sketch-note.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-label="Patient Support Program sketch note placeholder">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f7fbff"/>
+      <stop offset="100%" stop-color="#eef4ff"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="1600" height="900" fill="url(#bg)"/>
+  <rect x="30" y="30" width="1540" height="840" rx="18" fill="none" stroke="#2f4f7f" stroke-width="6"/>
+  <text x="800" y="280" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="58" font-weight="700" fill="#1f3b63">
+    Patient Support Program (PSP) Sketch Note
+  </text>
+  <line x1="220" y1="360" x2="1380" y2="360" stroke="#b8c9e6" stroke-width="4"/>
+  <line x1="220" y1="520" x2="1380" y2="520" stroke="#b8c9e6" stroke-width="4"/>
+  <text x="800" y="450" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="34" fill="#2f4f7f">
+    Image file is now embedded and visible in the post.
+  </text>
+  <text x="800" y="580" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="30" fill="#2f4f7f">
+    Replace this SVG with your final sketchnote image if needed.
+  </text>
+  <text x="800" y="650" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="26" fill="#466289">
+    Path: /images/psp-sketch-note.svg
+  </text>
+</svg>


### PR DESCRIPTION
### Motivation

- Provide a concise, accessible explainer on Patient Support Programs (PSPs) to surface how PSPs impact patient starts and pharma revenue. 
- Include a visual sketch-note to accompany the post and make the end-to-end PSP pipeline easier to understand.

### Description

- Add a new blog post at `_posts/2026-04-22-HowPatientSupportProgramsDrivePharmaGrowth.md` with frontmatter tags and a step-by-step explainer of the PSP journey and business metrics. 
- Embed a placeholder sketch-note SVG at `images/psp-sketch-note.svg` and reference it in the post for inline visualization. 
- The SVG contains a simple styled canvas and instructional text indicating it can be replaced with a final sketchnote image.

### Testing

- Built the site locally with `jekyll build` to validate the new post and image were processed without build errors. 
- Ran a basic HTML/link check with `htmlproofer` against the generated site and found no broken internal links or missing assets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e86402dc448329aa523c751e90f231)